### PR TITLE
fix: OGP画像のデザインをサイトと統一

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
   },
   // Twitter(X)カード設定
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: SITE_NAME,
     description: '富山湾のホタルイカ身投げをAIで予測。掲示板で現地の最新情報をリアルタイムに交換できます。',
   },

--- a/frontend/app/opengraph-image.tsx
+++ b/frontend/app/opengraph-image.tsx
@@ -8,9 +8,11 @@ export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const iconData = await readFile(
-    join(process.cwd(), 'public/hotaruika_aikon_3.png')
-  );
+  const [fontData, iconData] = await Promise.all([
+    readFile(join(process.cwd(), 'public/fonts/ZenKakuGothicNew-Bold.ttf')),
+    readFile(join(process.cwd(), 'public/hotaruika_aikon_3.png')),
+  ]);
+
   const iconBase64 = `data:image/png;base64,${iconData.toString('base64')}`;
 
   return new ImageResponse(
@@ -22,12 +24,69 @@ export default async function Image() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          background: 'linear-gradient(135deg, #0f172a 0%, #1e3a5f 50%, #312e81 100%)',
+          background: 'linear-gradient(135deg, #0f172a 0%, #1e3a8a 50%, #312e81 100%)',
+          fontFamily: '"Zen Kaku Gothic New"',
         }}
       >
-        <img src={iconBase64} width={400} height={400} alt="" />
+        <img
+          src={iconBase64}
+          width={240}
+          height={240}
+          style={{ marginRight: 48 }}
+          alt=""
+        />
+
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 16,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 64,
+              fontWeight: 700,
+              lineHeight: 1.2,
+              backgroundImage: 'linear-gradient(to right, #93c5fd, #d8b4fe, #f9a8d4)',
+              backgroundClip: 'text',
+              color: 'transparent',
+            }}
+          >
+            ホタルイカ爆湧き予報
+          </div>
+          <div
+            style={{
+              fontSize: 28,
+              color: '#bfdbfe',
+              lineHeight: 1.5,
+              maxWidth: 600,
+            }}
+          >
+            ホタルイカの身投げをAIで予測
+          </div>
+          <div
+            style={{
+              fontSize: 24,
+              color: '#93c5fd',
+              marginTop: 8,
+            }}
+          >
+            bakuwaki.jp
+          </div>
+        </div>
       </div>
     ),
-    { ...size }
+    {
+      ...size,
+      fonts: [
+        {
+          name: 'Zen Kaku Gothic New',
+          data: fontData,
+          style: 'normal',
+          weight: 700,
+        },
+      ],
+    }
   );
 }


### PR DESCRIPTION
テキストをサイトと同じグラデーション・配色に変更し、カードタイプをsummary_large_imageに戻す